### PR TITLE
Basic actor workflow. No classification, ad inserted always at the end of…

### DIFF
--- a/src/main/scala/pl/edu/pw/elka/adoptimizer/adinsertion/AdInserterActor.scala
+++ b/src/main/scala/pl/edu/pw/elka/adoptimizer/adinsertion/AdInserterActor.scala
@@ -1,0 +1,67 @@
+package pl.edu.pw.elka.adoptimizer.adinsertion
+
+import java.util.concurrent.TimeUnit
+
+import akka.actor.{ Actor, ActorLogging, ActorRef, Props }
+import akka.util.Timeout
+import akka.pattern.ask
+import pl.edu.pw.elka.adoptimizer.categorization.EnsembleActor
+import pl.edu.pw.elka.adoptimizer.categorization.model.Message.Classify
+import pl.edu.pw.elka.adoptimizer.categorization.model.Sample
+import pl.edu.pw.elka.adoptimizer.domain.Ad
+import pl.edu.pw.elka.adoptimizer.http.AdOptimizer
+import pl.edu.pw.elka.adoptimizer.parsing.WebsiteParserActor
+import pl.edu.pw.elka.adoptimizer.parsing.WebsiteParserActor.{ AppendContentToParagraph, ExtractParagraphs, Paragraph }
+
+import scala.collection.mutable
+import scala.collection.mutable.ListBuffer
+import scala.concurrent.Await
+
+object AdInserterActor {
+  type ClassificationResultsType = mutable.SortedMap[Double, Paragraph]
+  final case class ParsedParagraphs(paragraphs: List[Paragraph])
+  final case class HtmlWithAd(htmlWithAd: String)
+  final case class ClassificationResults(classificationResults: ClassificationResultsType)
+  def props: Props = Props[AdInserterActor]
+}
+
+class AdInserterActor extends Actor with ActorLogging {
+  import AdInserterActor._
+  import pl.edu.pw.elka.adoptimizer.api.AdApiActor.InsertAd
+
+  var requestOriginActor: ActorRef = _
+  var adToInsert: Ad = _
+  var targetWebsite: String = _
+
+  private var parsingActor = context.actorOf(WebsiteParserActor.props)
+  private var classificationActor = context.actorOf(WebsiteParserActor.props)
+
+  def receive: Receive = {
+    case InsertAd(website, ad) =>
+      requestOriginActor = sender()
+      adToInsert = ad
+      targetWebsite = website
+      parsingActor ! ExtractParagraphs(website)
+    case ParsedParagraphs(paragraphs) =>
+      if (paragraphs.isEmpty) {
+        requestOriginActor ! targetWebsite
+      } else {
+        classifyParagraphs(paragraphs)
+      }
+    case ClassificationResults(classificationResults) =>
+      val (bestResult, bestParagraph) = classificationResults.head
+      parsingActor ! AppendContentToParagraph(targetWebsite, bestParagraph, adToInsert.content)
+    case HtmlWithAd(htmlWithAd) =>
+      requestOriginActor ! htmlWithAd
+      context.stop(parsingActor)
+      context.stop(classificationActor)
+      context.stop(self)
+  }
+
+  def classifyParagraphs(paragraphs: List[Paragraph]) = {
+    val classificationResults: ClassificationResultsType = mutable.SortedMap()
+    classificationResults += ((1.0, paragraphs.head))
+    self ! ClassificationResults(classificationResults)
+  }
+
+}

--- a/src/main/scala/pl/edu/pw/elka/adoptimizer/api/AdApiActor.scala
+++ b/src/main/scala/pl/edu/pw/elka/adoptimizer/api/AdApiActor.scala
@@ -1,6 +1,7 @@
 package pl.edu.pw.elka.adoptimizer.api
 
 import akka.actor.{ Actor, ActorLogging, Props }
+import pl.edu.pw.elka.adoptimizer.adinsertion.AdInserterActor
 import pl.edu.pw.elka.adoptimizer.domain.Ad
 
 object AdApiActor {
@@ -14,6 +15,7 @@ class AdApiActor extends Actor with ActorLogging {
 
   def receive: Receive = {
     case InsertAd(website, ad) =>
-      sender() ! website
+      val inserterActor = context.actorOf(AdInserterActor.props)
+      inserterActor forward InsertAd(website, ad)
   }
 }

--- a/src/main/scala/pl/edu/pw/elka/adoptimizer/http/AdOptimizer.scala
+++ b/src/main/scala/pl/edu/pw/elka/adoptimizer/http/AdOptimizer.scala
@@ -6,7 +6,9 @@ import akka.http.scaladsl.Http
 import akka.http.scaladsl.Http.ServerBinding
 import akka.stream.ActorMaterializer
 import pl.edu.pw.elka.adoptimizer.api.{ AdApiActor, SystemApiActor }
+import pl.edu.pw.elka.adoptimizer.categorization.EnsembleActor
 import pl.edu.pw.elka.adoptimizer.http.routes.{ AdRoutes, SystemRoutes }
+import pl.edu.pw.elka.adoptimizer.parsing.WebsiteParserActor
 
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.io.StdIn

--- a/src/main/scala/pl/edu/pw/elka/adoptimizer/http/routes/AdRoutes.scala
+++ b/src/main/scala/pl/edu/pw/elka/adoptimizer/http/routes/AdRoutes.scala
@@ -24,7 +24,7 @@ object AdRoutes extends JsonSupport {
   def routes(adActor: ActorRef): Route =
     pathPrefix("ad") {
       pathEnd {
-        get {
+        post {
           entity(as[AdForWebsite]) { adForWebsite =>
             val websiteWithAd: Future[String] =
               (adActor ? InsertAd(adForWebsite.websiteHtml, adForWebsite.ad)).mapTo[String]

--- a/src/main/scala/pl/edu/pw/elka/adoptimizer/parsing/WebsiteParserActor.scala
+++ b/src/main/scala/pl/edu/pw/elka/adoptimizer/parsing/WebsiteParserActor.scala
@@ -3,6 +3,7 @@ package pl.edu.pw.elka.adoptimizer.parsing
 import scala.collection.JavaConverters._
 import akka.actor.{ Actor, Props }
 import org.jsoup.Jsoup
+import pl.edu.pw.elka.adoptimizer.adinsertion.AdInserterActor.{ HtmlWithAd, ParsedParagraphs }
 import pl.edu.pw.elka.adoptimizer.parsing.WebsiteParserActor.{ AppendContentToParagraph, ExtractParagraphs, Paragraph }
 
 object WebsiteParserActor {
@@ -15,8 +16,8 @@ object WebsiteParserActor {
 
 class WebsiteParserActor extends Actor {
 
-  private def getParagraphs(html: String): List[Paragraph] =
-    Jsoup.parse(html).select("p").asScala.map(_.text()).toList
+  private def getParagraphs(html: String) =
+    ParsedParagraphs(paragraphs = Jsoup.parse(html).select("p").asScala.map(_.text()).toList)
 
   private def insertAfterParagraph(html: String, paragraphToInsertAfter: String, contentToInsert: String) = {
     val doc = Jsoup.parse(html)
@@ -27,7 +28,7 @@ class WebsiteParserActor extends Actor {
         .attr("style", "display: block")
         .appendText(contentToInsert))
 
-    doc.html()
+    HtmlWithAd(htmlWithAd = doc.html())
   }
 
   override def receive: Receive = {

--- a/src/test/scala/pl/edu/pw/elka/adoptimizer/AdRoutesSpec.scala
+++ b/src/test/scala/pl/edu/pw/elka/adoptimizer/AdRoutesSpec.scala
@@ -8,13 +8,14 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{ Matchers, WordSpec }
 import pl.edu.pw.elka.adoptimizer.api.AdApiActor
 import pl.edu.pw.elka.adoptimizer.domain.Ad
-import pl.edu.pw.elka.adoptimizer.http.JsonSupport
+import pl.edu.pw.elka.adoptimizer.http.{ AdOptimizer, JsonSupport }
 import pl.edu.pw.elka.adoptimizer.http.routes.{ AdForWebsite, AdRoutes }
 
 class AdRoutesSpec extends WordSpec with Matchers with ScalaFutures with ScalatestRouteTest with JsonSupport {
   val testAdCategory = "test"
   val testAdContent = "test content"
-  val testWebsiteContent = "<html>test</html>"
+  val testWebsiteContentNoParagraphs = "<html>test</html>"
+  val testWebsiteContentWithParagraphs = "<html><head></head><p>test1</p><p>test2</p><p>test3</p></html>"
 
   val adActor: ActorRef =
     system.actorOf(AdApiActor.props, "adActor")
@@ -22,17 +23,33 @@ class AdRoutesSpec extends WordSpec with Matchers with ScalaFutures with Scalate
   lazy val routes = AdRoutes.routes(adActor)
 
   "AdRoutes" should {
-    "return website for (GET /ad)" in {
-      val adRequest = AdForWebsite(testWebsiteContent, Ad(testAdCategory, testAdContent))
+    "return unmodified website for (POST /ad), website with no <p> tags" in {
+      val adRequest = AdForWebsite(testWebsiteContentNoParagraphs, Ad(testAdCategory, testAdContent))
       val adEntity = Marshal(adRequest).to[MessageEntity].futureValue
-      val request = Get("/ad").withEntity(adEntity)
+      val request = Post("/ad").withEntity(adEntity)
 
       request ~> routes ~> check {
         status should ===(StatusCodes.OK)
 
         contentType should ===(ContentTypes.`text/plain(UTF-8)`)
 
-        entityAs[String] should ===(testWebsiteContent)
+        entityAs[String] should ===(testWebsiteContentNoParagraphs)
+      }
+    }
+  }
+  "AdRoutes" should {
+    "return website with inserted ad at the end of the first <p> for (POST /ad), website with <p> tags" in {
+      val adRequest = AdForWebsite(testWebsiteContentWithParagraphs, Ad(testAdCategory, testAdContent))
+      val adEntity = Marshal(adRequest).to[MessageEntity].futureValue
+      val request = Post("/ad").withEntity(adEntity)
+      val expectedWebsiteWithInsertedAd = "<html>\n <head></head>\n <body>\n  <p>test1<b style=\"display: block\">test content</b></p>\n  <p>test2</p>\n  <p>test3</p>\n </body>\n</html>"
+
+      request ~> routes ~> check {
+        status should ===(StatusCodes.OK)
+
+        contentType should ===(ContentTypes.`text/plain(UTF-8)`)
+
+        entityAs[String] should ===(expectedWebsiteWithInsertedAd)
       }
     }
   }

--- a/src/test/scala/pl/edu/pw/elka/adoptimizer/parsing/WebsiteParserActorSpec.scala
+++ b/src/test/scala/pl/edu/pw/elka/adoptimizer/parsing/WebsiteParserActorSpec.scala
@@ -8,6 +8,7 @@ import org.scalatest.concurrent.ScalaFutures
 import pl.edu.pw.elka.adoptimizer.parsing.WebsiteParserActor.{ AppendContentToParagraph, ExtractParagraphs }
 import akka.pattern.ask
 import org.scalatest.time.{ Millis, Seconds, Span }
+import pl.edu.pw.elka.adoptimizer.adinsertion.AdInserterActor.{ HtmlWithAd, ParsedParagraphs }
 
 import scala.concurrent.duration._
 
@@ -28,7 +29,7 @@ class WebsiteParserActorSpec extends TestKit(ActorSystem("ParserSpec"))
   "Website parser" should {
     "return all paragraphs for website" in {
       whenReady(parserActor ? ExtractParagraphs(html)) { result =>
-        result shouldBe List("Paragraph 1", "Paragraph 2")
+        result shouldBe ParsedParagraphs(List("Paragraph 1", "Paragraph 2"))
       }
     }
 
@@ -36,7 +37,7 @@ class WebsiteParserActorSpec extends TestKit(ActorSystem("ParserSpec"))
       val expectedHtml = "<html><head></head><body><p>Paragraph 1" +
         "<b style=\"display: block\">test</b></p><img><p>Paragraph 2</p></body></html>"
       whenReady(parserActor ? AppendContentToParagraph(html, "Paragraph 1", "test")) { result =>
-        result.toString.split("\n").map(_.trim).reduce(_ + _) shouldBe expectedHtml
+        result.toString.split("\n").map(_.trim).reduce(_ + _) shouldBe HtmlWithAd(expectedHtml).toString()
       }
     }
   }


### PR DESCRIPTION
… the first <p> block. Added test. Changed request method to POST. Parsing and classification actors created for each request to keep it simple before implementing actor pools.